### PR TITLE
Fix link

### DIFF
--- a/src/usr/local/kobocloud/getOwncloudList.sh
+++ b/src/usr/local/kobocloud/getOwncloudList.sh
@@ -12,4 +12,4 @@ echo '<?xml version="1.0"?>
 </a:propfind>' |
 $CURL -k --silent -i -X PROPFIND -u $user: $davServer/public.php/webdav --upload-file - -H "Depth: 1" | # get the listing
 grep -Eo '<d:href>[^<]*[^/]</d:href>' | # get the links without the folders
-sed 's@</*d:href>@@g' # remove the hrefs
+sed 's@</*d:href>/@@g' # remove the hrefs


### PR DESCRIPTION
The leading '/' needs to be omitted from the links to prevent problems when downloading the books. The script adds the '/' later, so if it is not omitted you get '//' which results in an error.